### PR TITLE
Issue 8: Facilitate deployment of artifacts to Artifactory via Drone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN mkdir /app
 
 WORKDIR /app
 
-COPY settings.xml.sub $HOME/.m2/.
+COPY settings.xml $HOME/.m2/
 
-COPY entrypoint.sh /root/entrypoint.sh
+ENTRYPOINT ["/bin/bash", "-c"]
 
-ENTRYPOINT ["/root/entrypoint.sh"]
+CMD ["mvn -v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/ukhomeofficedigital/openjdk8:latest
 
 RUN yum clean all && \
     yum update -y && \
-    yum install -y wget curl unzip gettext git && \
+    yum install -y git && \
     yum clean all && \
     rpm --rebuilddb
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ pipeline:
     drone_s3_cache_mode: "push"
 ```
 
+To deploy artifacts to Artifactory, please pass valid credentials via the ARTIFACTORY\_USERNAME and ARTIFACTORY\_PASSWORD environment variables.
+
+You'll also need to include the following in your POM file:
+```
+<distributionManagement>
+        <repository>
+                <id>artifactory</id>
+                <name>libs-release-local</name>
+                <url>https://artifactory.digital.homeoffice.gov.uk/artifactory/libs-release-local</url>
+        </repository>
+        <snapshotRepository>
+                <id>artifactory</id>
+                <name>libs-snapshot-local</name>
+                <url>https://artifactory.digital.homeoffice.gov.uk/artifactory/libs-snapshot-local</url>
+        </snapshotRepository>
+</distributionManagement>
+```
+Maven should then deploy to Artifactory during the "deploy" lifecycle phase.
+
 ## Contributing
 
 Feel free to submit pull requests and issues. If it's a particularly large PR, you may wish to

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-envsubst < ${HOME}/.m2/settings.xml.sub > ${HOME}/.m2/settings.xml
-rm -f ${HOME}/.m2/settings.xml.sub
-
-CMD=( "${@:1}" )
-
-eval "${CMD[*]}"

--- a/settings.xml
+++ b/settings.xml
@@ -3,8 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <servers>
     <server>
-      <username>${ARTIFACTORY_USERNAME}</username>
-      <password>${ARTIFACTORY_PASSWORD}</password>
+      <username>${env.ARTIFACTORY_USERNAME}</username>
+      <password>${env.ARTIFACTORY_PASSWORD}</password>
       <id>artifactory</id>
     </server>
   </servers>


### PR DESCRIPTION
Rework image to remove the need for an entrypoint script (Drone is likely to override the default entrypoint).

Maven now sources Artifactory credentials directly from the appropriate environment variables.

Update README: add instructions for deploying to Artifactory.