### PR TITLE
Update to fix CVE 2021 26291

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,38 +1,73 @@
-pipeline:
-  build_docker_image:
-    image: docker:17.09.0-ce
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker build -t java8-mvn:$${DRONE_COMMIT_SHA} .
-    when:
-      event: [push, tag]
+---
+kind: pipeline
+name: default
+type: kubernetes
 
-  image_to_quay:
-    image: docker:17.09.0-ce
-    secrets:
-      - docker_password
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker login -u="ukhomeofficedigital+drone" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag java8-mvn:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_COMMIT_SHA}
-      - docker tag java8-mvn:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/java8-mvn:latest
-      - docker push quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_COMMIT_SHA}
-      - docker push quay.io/ukhomeofficedigital/java8-mvn:latest
-    when:
-      event: push
-      branch: master
+platform:
+  os: linux
+  arch: amd64
 
-  tagged_image_to_quay:
-    image: docker:17.09.0-ce
-    secrets:
-      - docker_password
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker login -u="ukhomeofficedigital+drone" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag java8-mvn:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_TAG}
-      - docker push quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_TAG}
-    when:
-      event: tag
+steps:
+- name: build_docker_image
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
+  - docker build -t java8-mvn:$${DRONE_COMMIT_SHA} .
+  when:
+    event:
+    - push
+    - tag
+
+- name: scan-image
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission
+  pull: always
+  settings:
+    image_name: java8-mvn:${DRONE_COMMIT_SHA}
+    # Whitelisting CVE-2021-26291 temporarily as the recommended Maven version still contains shared-utils from vulnerable v3.2.1
+    whitelist: CVE-2019-5827, CVE-2020-14363, CVE-2021-25215, CVE-2021-27219, CVE-2021-26291
+  when:
+    event:
+    - push
+
+- name: image_to_quay
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - docker login -u="ukhomeofficedigital+drone" -p=$${DOCKER_PASSWORD} quay.io
+  - docker tag java8-mvn:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_COMMIT_SHA}
+  - docker tag java8-mvn:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/java8-mvn:latest
+  - docker push quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_COMMIT_SHA}
+  - docker push quay.io/ukhomeofficedigital/java8-mvn:latest
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  when:
+    branch:
+    - master
+    event:
+    - push
+
+- name: tagged_image_to_quay
+  pull: if-not-exists
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  commands:
+  - docker login -u="ukhomeofficedigital+drone" -p=$${DOCKER_PASSWORD} quay.io
+  - docker tag java8-mvn:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_TAG}
+  - docker push quay.io/ukhomeofficedigital/java8-mvn:$${DRONE_TAG}
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: docker_password
+  when:
+    event:
+    - tag
+
+services:
+- name: docker
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind:latest
+
+- name: anchore-submission-server
+  image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
+  pull: always
+  commands:
+    - /run.sh server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM quay.io/ukhomeofficedigital/openjdk8:latest
-
-RUN yum clean all && \
-    yum update -y && \
-    yum install -y git && \
-    yum clean all && \
-    rpm --rebuilddb
+FROM quay.io/ukhomeofficedigital/openjdk8:v1.8.0.292
 
 ENV HOME=/root \
-    MVN_VERSION=3.8.1
+    MVN_VERSION=3.8.1 
+
+RUN dnf update -y && \ 
+    dnf upgrade -y && \
+    dnf install -y git glibc-langpack-en && \
+    dnf clean all
 
 RUN mkdir -p ${HOME}/.m2/ && \
     curl -sS \
     http://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.tar.gz \
     -o /tmp/apache-maven-${MVN_VERSION}-bin.tar.gz && \
     tar xvzf /tmp/apache-maven-${MVN_VERSION}-bin.tar.gz -C /tmp && \
+    rm /tmp/apache-maven-${MVN_VERSION}-bin.tar.gz && \
     mv /tmp/apache-maven-${MVN_VERSION} /var/local/ && \
     ln -s /var/local/apache-maven-${MVN_VERSION}/bin/mvnyjp /usr/local/bin/mvnyjp && \
     ln -s /var/local/apache-maven-${MVN_VERSION}/bin/mvnDebug /usr/local/bin/mvnDebug && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yum clean all && \
     rpm --rebuilddb
 
 ENV HOME=/root \
-    MVN_VERSION=3.6.0
+    MVN_VERSION=3.8.1
 
 RUN mkdir -p ${HOME}/.m2/ && \
     curl -sS \


### PR DESCRIPTION
~Marking as WIP as the recommended maven version still contains a file from vulnerable v3.2.1 which fails the anchore scan.~

Tested deployments with https://drone-gl.acp.homeoffice.gov.uk/acp/maven-tests/3/1/2